### PR TITLE
docs(contributing): add CONTRIBUTING.md with quick start guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing to TACT
+
+Thanks for your interest in contributing! Small improvements (typos, docs, examples) are especially welcome.
+
+## Quick start
+
+1. Fork the repository and create a branch named like:
+   - `docs/fix-readme-<short-desc>`
+   - `chore/add-contributing`
+2. Make small, focused changes. Prefer one logical change per commit.
+3. Use a clear commit message (see examples below).
+4. Push the branch to your fork and open a Pull Request targeting `main`.
+
+## Commit message examples
+
+- `docs(readme): fix grammar in Installation section`
+- `docs(readme): add npm install alternative`
+- `docs(contributing): add contributing guide`
+
+## PR expectations
+
+When opening a PR, please include:
+- **Current behavior** — short description of what exists now (if applicable)
+- **New behavior** — what your change does
+- **Breaking changes** — mark `None` if there are none
+- **Other info** — any testing notes, references or screenshots
+
+For larger changes (language design, compiler internals), please open an issue first to discuss the proposed design.
+
+Thanks — maintainers will review and help improve your contribution!


### PR DESCRIPTION
Added CONTRIBUTING.md to lower the barrier for new contributors.

Contents include:
- Quick start steps for forking, branching and opening PRs
- Commit message examples
- PR expectations (Current behavior / New behavior / Breaking changes / Other info)
- Note to open an issue for larger design changes

Rationale:
- A short contributing guide helps maintainers by improving incoming PR quality and reducing repetitive feedback.